### PR TITLE
feat: add 'open-bg' launch type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ interface LaunchIDEParams {
   /**
    * @optional
    * @type: string
-   * @description: The ways to launch the editor. exec: opening editor using the executable path; open: opening editor using the open command. Only effective on MacOS and these editors: code/cursor/windsurf/qoder/comate/trae/codebuddy/antigravity/kiro/codium
+   * @description: The ways to launch the editor. `exec`: opening editor using the executable path. `open`: opening editor using the macOS `open` command (activates the editor). `openInBackground`: like `open` but adds the `-g` flag, so the file opens at the right line without bringing the editor to the foreground — the user's current window (e.g. browser) keeps focus. `open` and `openInBackground` are only effective on MacOS and these editors: code/cursor/windsurf/qoder/comate/trae/codebuddy/antigravity/kiro/codium
    * @default exec
    */
-  type?: 'exec' | 'open';
+  type?: 'exec' | 'open' | 'openInBackground';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ interface LaunchIDEParams {
   /**
    * @optional
    * @type: string
-   * @description: The ways to launch the editor. `exec`: opening editor using the executable path. `open`: opening editor using the macOS `open` command (activates the editor). `openInBackground`: like `open` but adds the `-g` flag, so the file opens at the right line without bringing the editor to the foreground — the user's current window (e.g. browser) keeps focus. `open` and `openInBackground` are only effective on MacOS and these editors: code/cursor/windsurf/qoder/comate/trae/codebuddy/antigravity/kiro/codium
+   * @description: The ways to launch the editor. `exec`: opening editor using the executable path. `open`: opening editor using the macOS `open` command (activates the editor). `open-bg`: like `open` but adds the `-g` flag, so the file opens at the right line without bringing the editor to the foreground — the user's current window (e.g. browser) keeps focus. `open` and `open-bg` are only effective on MacOS and these editors: code/cursor/windsurf/qoder/comate/trae/codebuddy/antigravity/kiro/codium
    * @default exec
    */
-  type?: 'exec' | 'open' | 'openInBackground';
+  type?: 'exec' | 'open' | 'open-bg';
 }
 ```
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -146,21 +146,24 @@ export function launchIDE(params: LaunchIDEParams) {
     editor
   ) as keyof EDITOR_PROCESS_MAP;
   if (
-    type === 'open' &&
+    (type === 'open' || type === 'openInBackground') &&
     process.platform === 'darwin' &&
     EDITORS_OPEN_MAP[editorBasename]
   ) {
-    _childProcess = child_process.spawn(
-      'open',
-      [`${EDITORS_OPEN_MAP[editorBasename]}://file${file}:${line}:${column}`],
-      {
-        stdio: 'ignore',
-        env: {
-          ...process.env,
-          NODE_OPTIONS: '',
-        },
-      }
-    );
+    // `-g` opens the URL via Launch Services without activating the target
+    // app, so the editor jumps to the file but the user's current window
+    // keeps focus. macOS-only; ignored on other platforms.
+    const openArgs =
+      type === 'openInBackground'
+        ? ['-g', `${EDITORS_OPEN_MAP[editorBasename]}://file${file}:${line}:${column}`]
+        : [`${EDITORS_OPEN_MAP[editorBasename]}://file${file}:${line}:${column}`];
+    _childProcess = child_process.spawn('open', openArgs, {
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        NODE_OPTIONS: '',
+      },
+    });
   } else {
     if (
       process.platform === 'linux' &&

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -146,17 +146,15 @@ export function launchIDE(params: LaunchIDEParams) {
     editor
   ) as keyof EDITOR_PROCESS_MAP;
   if (
-    (type === 'open' || type === 'openInBackground') &&
+    (type === 'open' || type === 'open-bg') &&
     process.platform === 'darwin' &&
     EDITORS_OPEN_MAP[editorBasename]
   ) {
     // `-g` opens the URL via Launch Services without activating the target
     // app, so the editor jumps to the file but the user's current window
     // keeps focus. macOS-only; ignored on other platforms.
-    const openArgs =
-      type === 'openInBackground'
-        ? ['-g', `${EDITORS_OPEN_MAP[editorBasename]}://file${file}:${line}:${column}`]
-        : [`${EDITORS_OPEN_MAP[editorBasename]}://file${file}:${line}:${column}`];
+    const url = `${EDITORS_OPEN_MAP[editorBasename]}://file${file}:${line}:${column}`;
+    const openArgs = type === 'open-bg' ? ['-g', url] : [url];
     _childProcess = child_process.spawn('open', openArgs, {
       stdio: 'ignore',
       env: {

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -35,4 +35,4 @@ export type EDITOR_PROCESS_MAP = {
 };
 export type IDEOpenMethod = 'reuse' | 'new' | 'auto';
 
-export type LaunchType = 'exec' | 'open';
+export type LaunchType = 'exec' | 'open' | 'openInBackground';

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -35,4 +35,4 @@ export type EDITOR_PROCESS_MAP = {
 };
 export type IDEOpenMethod = 'reuse' | 'new' | 'auto';
 
-export type LaunchType = 'exec' | 'open' | 'openInBackground';
+export type LaunchType = 'exec' | 'open' | 'open-bg';

--- a/types/type.d.ts
+++ b/types/type.d.ts
@@ -4,4 +4,4 @@ export type EDITOR_PROCESS_MAP = {
     [key in Editor]?: string[];
 };
 export type IDEOpenMethod = 'reuse' | 'new' | 'auto';
-export type LaunchType = 'exec' | 'open';
+export type LaunchType = 'exec' | 'open' | 'openInBackground';

--- a/types/type.d.ts
+++ b/types/type.d.ts
@@ -4,4 +4,4 @@ export type EDITOR_PROCESS_MAP = {
     [key in Editor]?: string[];
 };
 export type IDEOpenMethod = 'reuse' | 'new' | 'auto';
-export type LaunchType = 'exec' | 'open' | 'openInBackground';
+export type LaunchType = 'exec' | 'open' | 'open-bg';


### PR DESCRIPTION
Found a need for this when using https://www.npmjs.com/package/@stinsky/xray

Can be extremely helpful to prevent the editor from stealing focus if i'm rapidly switching between inspection and actual site navigation. Have to click on the site itself to send the xray toggle keystroke, which would of course be treated as another inspection and trigger launch-ide, changing the element I was just looking at. 

Have been running with this change patched for a while and found it to be a helpful dev experience. I imagine other upstream users of this package could also find this change helpful.

LMK if I'm missing anything, and thanks for your work on this project @zh-lx 