### PR TITLE
feat: compatible for zed

### DIFF
--- a/lib/editor-info/linux.ts
+++ b/lib/editor-info/linux.ts
@@ -32,6 +32,8 @@ export const COMMON_EDITORS_LINUX = {
   'goland.sh': 'goland',
   rider: 'rider',
   'rider.sh': 'rider',
+  trae: 'trae',
+  zed: 'zed',
 };
 
 export const EDITOR_PROCESS_MAP_LINUX: EDITOR_PROCESS_MAP = {

--- a/lib/editor-info/mac.ts
+++ b/lib/editor-info/mac.ts
@@ -1,4 +1,4 @@
-import { EDITOR_PROCESS_MAP } from '../type';
+import { Editor, EDITOR_PROCESS_MAP } from '../type';
 
 // 有顺序优先级
 export const COMMON_EDITORS_OSX = {
@@ -82,7 +82,10 @@ export const EDITOR_PROCESS_MAP_OSX: EDITOR_PROCESS_MAP = {
     '/Applications/CodeBuddy CN.app/Contents/MacOS/Electron',
   ],
   antigravity: ['Antigravity.app/Contents/MacOS/Electron'],
-  code: ['/Visual Studio Code.app/Contents/MacOS/Electron', '/Visual Studio Code.app/Contents/MacOS/Code'],
+  code: [
+    '/Visual Studio Code.app/Contents/MacOS/Electron',
+    '/Visual Studio Code.app/Contents/MacOS/Code',
+  ],
   'code-insiders': [
     '/Visual Studio Code - Insiders.app/Contents/MacOS/Electron',
   ],
@@ -117,4 +120,7 @@ export const EDITORS_OPEN_MAP: Partial<
   antigravity: 'antigravity',
   code: 'vscode',
   codium: 'vscodium',
+  zed: 'zed',
 };
+
+export const Force_Open_List: Editor[] = ['zed'];

--- a/lib/editor-info/windows.ts
+++ b/lib/editor-info/windows.ts
@@ -40,6 +40,7 @@ export const COMMON_EDITORS_WIN: { [key: string]: string } = {
   'goland64.exe': '',
   'rider.exe': '',
   'rider64.exe': '',
+  'zed.exe': '',
 };
 
 export const EDITOR_PROCESS_MAP_WIN: EDITOR_PROCESS_MAP = {
@@ -72,4 +73,5 @@ export const EDITOR_PROCESS_MAP_WIN: EDITOR_PROCESS_MAP = {
   rubymine: ['rubymine.exe', 'rubymine64.exe'],
   sublime: ['sublime_text.exe'],
   notepad: ['notepad++.exe'],
+  zed: ['zed.exe'],
 };

--- a/lib/get-args.ts
+++ b/lib/get-args.ts
@@ -15,7 +15,7 @@ export function formatOpenPath(
   file: string,
   line: string | number,
   column: string | number,
-  format: string | string[] | boolean
+  format: string | string[] | boolean,
 ) {
   let path = `${file}:${line}:${column}`;
   if (typeof format === 'string') {
@@ -74,7 +74,11 @@ export function getEditorBasenameByProcessName(processName: string) {
   for (let i = 0; i < editorBasenames.length; i++) {
     const editorPaths =
       COMMON_EDITOR_PROCESS_MAP[platform][editorBasenames[i] as Editor] || [];
-    if (editorPaths.some((editorPath) => processName.endsWith(editorPath))) {
+    if (
+      editorPaths.some((editorPath) =>
+        processName.toLowerCase().endsWith(editorPath.toLowerCase()),
+      )
+    ) {
       editorBasename = editorBasenames[i];
       break;
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,7 +12,7 @@ import type {
 import { getArguments, getEditorBasenameByProcessName } from './get-args';
 import { guessEditor } from './guess';
 import { getEnvVariable } from './utils';
-import { EDITORS_OPEN_MAP } from './editor-info/mac';
+import { EDITORS_OPEN_MAP, Force_Open_List } from './editor-info/mac';
 
 function isTerminalEditor(editor: string) {
   switch (editor) {
@@ -27,7 +27,7 @@ function isTerminalEditor(editor: string) {
 function getEnvFormatPath(rootDir: string) {
   const codeInspectorFormatPath = getEnvVariable(
     'CODE_INSPECTOR_FORMAT_PATH',
-    rootDir
+    rootDir,
   );
   if (codeInspectorFormatPath) {
     try {
@@ -42,14 +42,14 @@ function getEnvFormatPath(rootDir: string) {
 
 function printInstructions(fileName: any, errorMessage: string | any[] | null) {
   console.log(
-    chalk.red('Could not open ' + path.basename(fileName) + ' in the editor.')
+    chalk.red('Could not open ' + path.basename(fileName) + ' in the editor.'),
   );
   if (errorMessage) {
     if (errorMessage[errorMessage.length - 1] !== '.') {
       errorMessage += '.';
     }
     console.log(
-      chalk.red('The editor process exited with an error: ' + errorMessage)
+      chalk.red('The editor process exited with an error: ' + errorMessage),
     );
   }
   console.log(
@@ -62,7 +62,7 @@ function printInstructions(fileName: any, errorMessage: string | any[] | null) {
       chalk.green('editor: "code"') +
       ' to CodeInspectorPlugin config, ' +
       'and then restart the development server. Learn more: ' +
-      chalk.green('https://goo.gl/MMTaZt')
+      chalk.green('https://goo.gl/MMTaZt'),
   );
 }
 
@@ -71,7 +71,7 @@ let _childProcess:
       kill: (arg0: string) => void;
       on: (
         arg0: string,
-        arg1: { (errorCode: any): void; (error: any): void }
+        arg1: { (errorCode: any): void; (error: any): void },
       ) => void;
     }
   | any
@@ -136,17 +136,19 @@ export function launchIDE(params: LaunchIDEParams) {
           chalk.green('editor: "code"') +
           ' to CodeInspectorPlugin config, ' +
           'and then restart the development server. Learn more: ' +
-          chalk.green('https://goo.gl/MMTaZt')
+          chalk.green('https://goo.gl/MMTaZt'),
       );
     }
     return;
   }
 
   const editorBasename = getEditorBasenameByProcessName(
-    editor
+    editor,
   ) as keyof EDITOR_PROCESS_MAP;
   if (
-    (type === 'open' || type === 'open-bg') &&
+    (type === 'open' ||
+      type === 'open-bg' ||
+      Force_Open_List.includes(editorBasename)) &&
     process.platform === 'darwin' &&
     EDITORS_OPEN_MAP[editorBasename]
   ) {
@@ -188,7 +190,7 @@ export function launchIDE(params: LaunchIDEParams) {
           workspace,
           openWindowParams: getOpenWindowParams(method),
           pathFormat,
-        })
+        }),
       );
     } else {
       args.push(file);

--- a/types/editor-info/linux.d.ts
+++ b/types/editor-info/linux.d.ts
@@ -30,5 +30,7 @@ export declare const COMMON_EDITORS_LINUX: {
     'goland.sh': string;
     rider: string;
     'rider.sh': string;
+    trae: string;
+    zed: string;
 };
 export declare const EDITOR_PROCESS_MAP_LINUX: EDITOR_PROCESS_MAP;

--- a/types/editor-info/mac.d.ts
+++ b/types/editor-info/mac.d.ts
@@ -1,4 +1,4 @@
-import { EDITOR_PROCESS_MAP } from '../type';
+import { Editor, EDITOR_PROCESS_MAP } from '../type';
 export declare const COMMON_EDITORS_OSX: {
     '/Kiro.app/Contents/MacOS/Electron': string;
     '/Antigravity.app/Contents/MacOS/Electron': string;
@@ -40,3 +40,4 @@ export declare const COMMON_EDITORS_OSX: {
 };
 export declare const EDITOR_PROCESS_MAP_OSX: EDITOR_PROCESS_MAP;
 export declare const EDITORS_OPEN_MAP: Partial<Record<keyof EDITOR_PROCESS_MAP, string>>;
+export declare const Force_Open_List: Editor[];


### PR DESCRIPTION
- use `open` as default launch type to open zed on Mac