### PR TITLE
feat: add Devin editor support

### DIFF
--- a/lib/editor-info/linux.ts
+++ b/lib/editor-info/linux.ts
@@ -5,6 +5,7 @@ export const EDITOR_PROCESS_MAP_LINUX: EDITOR_PROCESS_MAP = {
   antigravity: ['antigravity'],
   webstorm: ['webstorm', 'webstorm.sh'],
   cursor: ['cursor'],
+  devin: ['devin'],
   windsurf: ['windsurf'],
   trae: ['trae'],
   comate: ['comate'],

--- a/lib/editor-info/mac.ts
+++ b/lib/editor-info/mac.ts
@@ -17,6 +17,10 @@ export const EDITOR_PROCESS_MAP_OSX: EDITOR_PROCESS_MAP = {
     '/Windsurf.app/Contents/MacOS/Electron',
     '/Windsurf.app/Contents/MacOS/Windsurf',
   ],
+  devin: [
+    'Devin.app/Contents/MacOS/Devin',
+    'Devin.app/Contents/MacOS/Electron',
+  ],
   trae: [
     '/Trae.app/Contents/MacOS/Electron',
     '/Trae CN.app/Contents/MacOS/Electron',
@@ -87,6 +91,7 @@ export const EDITORS_OPEN_MAP: Partial<
   cursor: 'cursor',
   comate: 'comate',
   qoder: 'qoder',
+  devin: 'devin',
   windsurf: 'windsurf',
   trae: 'trae',
   codebuddy: 'codebuddy',

--- a/lib/editor-info/windows.ts
+++ b/lib/editor-info/windows.ts
@@ -6,6 +6,7 @@ export const EDITOR_PROCESS_MAP_WIN: EDITOR_PROCESS_MAP = {
   webstorm: ['webstorm.exe', 'webstorm64.exe'],
   cursor: ['Cursor.exe'],
   windsurf: ['Windsurf.exe'],
+  devin: ['Devin.exe'],
   trae: ['Trae.exe', 'Trae CN.exe'],
   comate: ['comate.exe'],
   qoder: ['Qoder.exe', 'Qoder CN.exe'],

--- a/lib/get-args.ts
+++ b/lib/get-args.ts
@@ -122,6 +122,7 @@ function getFormatByEditor(params: GetEditorFormatParams) {
     case 'codium':
     case 'cursor':
     case 'windsurf':
+    case 'devin':
     case 'trae':
     case 'codebuddy':
     case 'antigravity':

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -12,6 +12,7 @@ export type Editor =
   | 'comate'
   | 'cursor'
   | 'colin'
+  | 'devin'
   | 'emacs'
   | 'goland'
   | 'hbuilder'

--- a/types/type.d.ts
+++ b/types/type.d.ts
@@ -1,4 +1,4 @@
-export type Editor = 'antigravity' | 'appcode' | 'atom' | 'kiro' | 'atom-beta' | 'brackets' | 'code' | 'code-insiders' | 'codebuddy' | 'codium' | 'comate' | 'cursor' | 'colin' | 'emacs' | 'goland' | 'hbuilder' | 'idea' | 'notepad' | 'phpstorm' | 'pycharm' | 'qoder' | 'trae' | 'rider' | 'rubymine' | 'sublime' | 'vim' | 'webstorm' | 'windsurf' | 'zed';
+export type Editor = 'antigravity' | 'appcode' | 'atom' | 'kiro' | 'atom-beta' | 'brackets' | 'code' | 'code-insiders' | 'codebuddy' | 'codium' | 'comate' | 'cursor' | 'colin' | 'devin' | 'emacs' | 'goland' | 'hbuilder' | 'idea' | 'notepad' | 'phpstorm' | 'pycharm' | 'qoder' | 'trae' | 'rider' | 'rubymine' | 'sublime' | 'vim' | 'webstorm' | 'windsurf' | 'zed';
 export type Platform = 'darwin' | 'linux' | 'win32';
 export type EDITOR_PROCESS_MAP = {
     [key in Editor]?: string[];


### PR DESCRIPTION
## Summary
- add Devin to supported editor types
- add Devin process mappings for macOS, Linux, and Windows
- support Devin in editor argument formatting

## Verification
- pnpm build