### PR TITLE
feat: support JetBrains new CLI

### DIFF
--- a/lib/get-args.ts
+++ b/lib/get-args.ts
@@ -55,7 +55,11 @@ export function getArguments(params: {
     openWindowParams,
     pathFormat,
   } = params;
-  const _params = { editorBasename, openWindowParams, workspace };
+  const _params = {
+    editorBasename,
+    openWindowParams,
+    workspace,
+  };
 
   const format = getFormatByEditor(_params) || DefaultPathFormat;
 
@@ -158,6 +162,8 @@ function getFormatByEditor(params: GetEditorFormatParams) {
         ...(workspace ? [workspace] : []),
         '--line',
         FormatLine,
+        '--column',
+        FormatColumn,
         FormatFile,
       ];
     case 'zed':

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,11 @@ import { getArguments, getEditorBasenameByProcessName } from './get-args';
 import { guessEditor } from './guess';
 import { getEnvVariable } from './utils';
 import { EDITORS_OPEN_MAP } from './editor-info/mac';
+import {
+  getJetBrainsWorkspace,
+  isJetBrainsEditor,
+  usesJetBrainsNewCli,
+} from './jetbrains';
 
 function isTerminalEditor(editor: string) {
   switch (editor) {
@@ -87,6 +92,38 @@ function getOpenWindowParams(ideOpenMethod?: IDEOpenMethod) {
   }
 }
 
+function spawnEditor(editor: string, args: string[]) {
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: '',
+  };
+
+  if (process.platform === 'win32') {
+    // These two funcs are from launch-editor and handle shell metacharacters.
+    const escapeCmdArgs = (cmdArg: string) =>
+      cmdArg.replace(/([&|<>,;=^])/g, '^$1');
+    const doubleQuoteIfNeeded = (value: string) => {
+      if (value.includes('^')) return `^"${value}^"`;
+      if (value.includes(' ')) return `"${value}"`;
+      return value;
+    };
+    const launchCommand = [editor, ...args.map(escapeCmdArgs)]
+      .map(doubleQuoteIfNeeded)
+      .join(' ');
+
+    return child_process.exec(launchCommand, {
+      // @ts-ignore
+      shell: true,
+      env,
+    });
+  }
+
+  return child_process.spawn(editor, args, {
+    stdio: 'ignore',
+    env,
+  });
+}
+
 interface LaunchIDEParams {
   file: string;
   line?: number;
@@ -118,6 +155,8 @@ export function launchIDE(params: LaunchIDEParams) {
   }
 
   let [editor, ...args] = guessEditor(_editor, rootDir, usePid);
+  const initialArgs = args.filter((arg): arg is string => arg !== null);
+  let fallbackArgs: string[] | null = null;
 
   // 获取 path format
   const pathFormat = getEnvFormatPath(rootDir || '') || format;
@@ -141,6 +180,7 @@ export function launchIDE(params: LaunchIDEParams) {
     }
     return;
   }
+  const editorCommand = editor;
 
   const editorBasename = getEditorBasenameByProcessName(
     editor,
@@ -177,8 +217,28 @@ export function launchIDE(params: LaunchIDEParams) {
       file = path.relative('', file);
     }
 
-    let workspace = null;
+    const useJetBrainsNewCli = usesJetBrainsNewCli(editor);
+    let workspace = useJetBrainsNewCli
+      ? getJetBrainsWorkspace(file, rootDir)
+      : null;
+    if (
+      workspace &&
+      process.platform === 'linux' &&
+      workspace.startsWith('/mnt/') &&
+      /Microsoft/i.test(os.release())
+    ) {
+      workspace = path.relative('', workspace);
+    }
     if (line) {
+      if (isJetBrainsEditor(editorBasename)) {
+        fallbackArgs = initialArgs.concat([
+          file,
+          '--line',
+          String(line),
+          '--column',
+          String(column),
+        ]);
+      }
       args = args.concat(
         getArguments({
           editorBasename,
@@ -201,64 +261,50 @@ export function launchIDE(params: LaunchIDEParams) {
       _childProcess.kill('SIGKILL');
     }
 
-    if (process.platform === 'win32') {
-      // this two funcs according to launch-editor
-      // compatible for some special characters
-      const escapeCmdArgs = (cmdArgs: string | null) => {
-        return cmdArgs!.replace(/([&|<>,;=^])/g, '^$1');
-      };
-      const doubleQuoteIfNeeded = (str: string | null) => {
-        if (str!.includes('^')) {
-          return `^"${str}^"`;
-        } else if (str!.includes(' ')) {
-          return `"${str}"`;
-        }
-        return str;
-      };
-
-      const launchCommand = [editor, ...args.map(escapeCmdArgs)]
-        .map(doubleQuoteIfNeeded)
-        .join(' ');
-
-      _childProcess = child_process.exec(launchCommand, {
-        stdio: 'ignore',
-        // @ts-ignore
-        shell: true,
-        env: {
-          ...process.env,
-          NODE_OPTIONS: '',
-        },
-      });
-    } else {
-      _childProcess = child_process.spawn(editor, args as string[], {
-        stdio: 'ignore',
-        env: {
-          ...process.env,
-          NODE_OPTIONS: '',
-        },
-      });
-    }
+    _childProcess = spawnEditor(editor, args as string[]);
   }
 
-  _childProcess.on('exit', function (errorCode: string) {
-    _childProcess = null;
-
-    if (errorCode) {
-      if (typeof onError === 'function') {
-        onError(file, '(code ' + errorCode + ')');
-      } else {
-        printInstructions(file, '(code ' + errorCode + ')');
-      }
-    }
-  });
-
-  _childProcess.on('error', function (error: { message: any }) {
+  const reportError = (errorMessage: string) => {
     if (typeof onError === 'function') {
-      onError(file, error.message);
+      onError(file, errorMessage);
     } else {
-      printInstructions(file, error.message);
+      printInstructions(file, errorMessage);
     }
-  });
+  };
+
+  const watchChildProcess = (childProcess: any) => {
+    let settled = false;
+
+    const handleFailure = (errorMessage: string) => {
+      if (settled) return;
+      settled = true;
+
+      if (fallbackArgs) {
+        const retryArgs = fallbackArgs;
+        fallbackArgs = null;
+        _childProcess = spawnEditor(editorCommand, retryArgs);
+        watchChildProcess(_childProcess);
+        return;
+      }
+
+      reportError(errorMessage);
+    };
+
+    childProcess.on('exit', function (errorCode: string | number | null) {
+      if (_childProcess === childProcess) _childProcess = null;
+      if (errorCode) {
+        handleFailure('(code ' + errorCode + ')');
+      } else {
+        settled = true;
+      }
+    });
+
+    childProcess.on('error', function (error: { message: string }) {
+      handleFailure(error.message);
+    });
+  };
+
+  watchChildProcess(_childProcess);
 }
 
 export * from './type';

--- a/lib/jetbrains.ts
+++ b/lib/jetbrains.ts
@@ -1,0 +1,134 @@
+import fs from 'fs';
+import path from 'path';
+
+interface JetBrainsProductInfo {
+  version?: string;
+  buildNumber?: string;
+}
+
+const NEW_CLI_BUILD_BRANCH = 262;
+const versionCache = new Map<string, boolean>();
+const jetBrainsEditors = new Set([
+  'appcode',
+  'clion',
+  'clion64',
+  'idea',
+  'idea64',
+  'phpstorm',
+  'phpstorm64',
+  'pycharm',
+  'pycharm64',
+  'rubymine',
+  'rubymine64',
+  'webstorm',
+  'webstorm64',
+  'goland',
+  'goland64',
+  'rider',
+  'rider64',
+]);
+
+export function isJetBrainsEditor(editorBasename: string): boolean {
+  return jetBrainsEditors.has(editorBasename);
+}
+
+export function getJetBrainsWorkspace(
+  file: string,
+  rootDir?: string,
+): string {
+  if (rootDir) {
+    const resolvedRootDir = path.resolve(rootDir);
+    if (fs.existsSync(resolvedRootDir)) return resolvedRootDir;
+  }
+
+  const ancestors: string[] = [];
+  let directory = path.dirname(path.resolve(file));
+
+  while (true) {
+    ancestors.push(directory);
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  for (const marker of ['.idea', '.git']) {
+    const workspace = ancestors.find((ancestor) =>
+      fs.existsSync(path.join(ancestor, marker)),
+    );
+    if (workspace) return workspace;
+  }
+
+  return path.dirname(path.resolve(file));
+}
+
+function resolveEditorPath(editor: string): string | null {
+  const candidates = editor.includes(path.sep)
+    ? [editor]
+    : (process.env.PATH || '')
+        .split(path.delimiter)
+        .filter(Boolean)
+        .map((directory) => path.join(directory, editor));
+
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) {
+        return fs.realpathSync(candidate);
+      }
+    } catch {
+      // Keep looking when a PATH entry or symlink cannot be resolved.
+    }
+  }
+
+  return null;
+}
+
+function getProductInfoPaths(editorPath: string): string[] {
+  const editorDirectory = path.dirname(editorPath);
+  return [
+    // macOS: <IDE>.app/Contents/MacOS/<launcher>
+    path.resolve(editorDirectory, '../Resources/product-info.json'),
+    // Linux/Windows: <IDE>/bin/<launcher>
+    path.resolve(editorDirectory, '../product-info.json'),
+  ];
+}
+
+function usesNewCli(productInfo: JetBrainsProductInfo): boolean {
+  const buildBranch = Number.parseInt(productInfo.buildNumber || '', 10);
+  if (!Number.isNaN(buildBranch)) {
+    return buildBranch >= NEW_CLI_BUILD_BRANCH;
+  }
+
+  const version = /^(\d{4})\.(\d+)/.exec(productInfo.version || '');
+  if (!version) return false;
+
+  const year = Number(version[1]);
+  const release = Number(version[2]);
+  return year > 2026 || (year === 2026 && release >= 2);
+}
+
+export function usesJetBrainsNewCli(editor: string): boolean {
+  const cached = versionCache.get(editor);
+  if (cached !== undefined) return cached;
+
+  const editorPath = resolveEditorPath(editor);
+  if (!editorPath) {
+    versionCache.set(editor, false);
+    return false;
+  }
+
+  for (const productInfoPath of getProductInfoPaths(editorPath)) {
+    try {
+      const productInfo = JSON.parse(
+        fs.readFileSync(productInfoPath, 'utf8'),
+      ) as JetBrainsProductInfo;
+      const result = usesNewCli(productInfo);
+      versionCache.set(editor, result);
+      return result;
+    } catch {
+      // Try the next platform-specific product-info.json location.
+    }
+  }
+
+  versionCache.set(editor, false);
+  return false;
+}

--- a/types/jetbrains.d.ts
+++ b/types/jetbrains.d.ts
@@ -1,0 +1,3 @@
+export declare function isJetBrainsEditor(editorBasename: string): boolean;
+export declare function getJetBrainsWorkspace(file: string, rootDir?: string): string;
+export declare function usesJetBrainsNewCli(editor: string): boolean;


### PR DESCRIPTION
## Summary

- detect JetBrains IDE versions that use the new CLI behavior
- resolve and pass the project workspace when opening a file location
- retry with the legacy argument order when the new CLI invocation fails
- include column information in supported editor arguments

## Verification

- `pnpm build`