### PR TITLE
feat: add separate workspace parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ interface LaunchIDEParams {
   /**
    * @optional
    * @type: string
+   * @description: the project directory used to find the .env.local file and environment variables
+   */
+  rootDir?: string;
+
+  /**
+   * @optional
+   * @type: string
+   * @description: the workspace directory to open in the editor
+   */
+  workspace?: string;
+
+  /**
+   * @optional
+   * @type: string
    * @description: Whether to guess the editor by the process id. When you use pid, the accuracy of the editor is higher, but the performance is lower.
    * @default false
    */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,6 +133,7 @@ interface LaunchIDEParams {
   format?: string | string[];
   onError?: (file: string, error: string) => void;
   rootDir?: string;
+  workspace?: string;
   usePid?: boolean;
   type?: LaunchType;
 }
@@ -147,6 +148,7 @@ export function launchIDE(params: LaunchIDEParams) {
     format,
     onError,
     rootDir,
+    workspace: workspacePath,
     usePid,
     type = 'exec',
   } = params;
@@ -218,9 +220,8 @@ export function launchIDE(params: LaunchIDEParams) {
     }
 
     const useJetBrainsNewCli = usesJetBrainsNewCli(editor);
-    let workspace = useJetBrainsNewCli
-      ? getJetBrainsWorkspace(file, rootDir)
-      : null;
+    let workspace =
+      workspacePath || (useJetBrainsNewCli ? getJetBrainsWorkspace(file) : null);
     if (
       workspace &&
       process.platform === 'linux' &&

--- a/lib/jetbrains.ts
+++ b/lib/jetbrains.ts
@@ -44,10 +44,10 @@ function getProjectRoot(): string {
   }
 }
 
-export function getJetBrainsWorkspace(file: string, rootDir?: string): string {
-  if (rootDir) {
-    const resolvedRootDir = path.resolve(rootDir);
-    if (fs.existsSync(resolvedRootDir)) return resolvedRootDir;
+export function getJetBrainsWorkspace(file: string, workspace?: string): string {
+  if (workspace) {
+    const resolvedWorkspace = path.resolve(workspace);
+    if (fs.existsSync(resolvedWorkspace)) return resolvedWorkspace;
   }
 
   const projectRoot = getProjectRoot();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ interface LaunchIDEParams {
     format?: string | string[];
     onError?: (file: string, error: string) => void;
     rootDir?: string;
+    workspace?: string;
     usePid?: boolean;
     type?: LaunchType;
 }

--- a/types/jetbrains.d.ts
+++ b/types/jetbrains.d.ts
@@ -1,3 +1,3 @@
 export declare function isJetBrainsEditor(editorBasename: string): boolean;
-export declare function getJetBrainsWorkspace(file: string, rootDir?: string): string;
+export declare function getJetBrainsWorkspace(file: string, workspace?: string): string;
 export declare function usesJetBrainsNewCli(editor: string): boolean;


### PR DESCRIPTION
## Summary

- Add a dedicated `workspace` option for editor workspace detection.
- Keep `rootDir` limited to `.env.local` and environment variable lookup.
- Preserve automatic workspace detection for JetBrains when `workspace` is omitted.
- Document both options and update generated TypeScript declarations.

## Verification

- `pnpm build`
- `git diff --check`