### PR TITLE
fix: support new Qoder process names

### DIFF
--- a/lib/editor-info/mac.ts
+++ b/lib/editor-info/mac.ts
@@ -8,6 +8,8 @@ export const EDITOR_PROCESS_MAP_OSX: EDITOR_PROCESS_MAP = {
     '/Comate.app/Contents/MacOS/Comate',
   ],
   qoder: [
+    '/Applications/Qoder IDE.app/Contents/MacOS/Qoder',
+    '/Applications/Qoder CN IDE.app/Contents/MacOS/Qoder CN',
     '/Qoder.app/Contents/MacOS/Electron',
     '/Qoder CN.app/Contents/MacOS/Electron',
     '/Qoder.app/Contents/MacOS/Qoder',

--- a/lib/editor-info/windows.ts
+++ b/lib/editor-info/windows.ts
@@ -9,7 +9,7 @@ export const EDITOR_PROCESS_MAP_WIN: EDITOR_PROCESS_MAP = {
   devin: ['Devin.exe'],
   trae: ['Trae.exe', 'Trae CN.exe'],
   comate: ['comate.exe'],
-  qoder: ['Qoder.exe', 'Qoder CN.exe'],
+  qoder: ['Qoder CN IDE.exe', 'Qoder IDE.exe', 'Qoder.exe', 'Qoder CN.exe'],
   codebuddy: ['CodeBuddy.exe', 'CodeBuddy CN.exe'],
   code: ['Code.exe'],
   'code-insiders': ['Code - Insiders.exe'],


### PR DESCRIPTION
## Summary
- add new Qoder IDE process paths on macOS
- recognize new Qoder IDE process names on Windows

## Verification
- pnpm build